### PR TITLE
Switch encodings to accomodate UTF8 with BOM

### DIFF
--- a/archieml/__init__.py
+++ b/archieml/__init__.py
@@ -126,7 +126,7 @@ class Loader(object):
         for line in fp:
             if hasattr(line, 'decode'):
                 # This is a byte string, decode it
-                line = line.decode('utf-8')
+                line = line.decode('utf-8-sig')
 
             scope = self.current_scope
             if self.done_parsing:


### PR DESCRIPTION
I think this little change will do the trick. It will ignore the BOM in UTF8 files that have it (such as Google Docs downloads). No difference for UTF8 files without a BOM.