### PR TITLE
use slugBlacklist and not \w-

### DIFF
--- a/archieml/__init__.py
+++ b/archieml/__init__.py
@@ -55,9 +55,15 @@ class Scope(object):
 
 class Loader(object):
     COMMAND_PATTERN = re.compile(r'^\s*:[ \t\r]*(?P<command>endskip|ignore|skip|end).*?(?:\n|\r|$)', re.IGNORECASE)
-    KEY_PATTERN     = re.compile(r'^\s*(?P<key>[\w-]+(?:\.[\w-]+)*)[ \t\r]*:[ \t\r]*(?P<value>.*(?:\n|\r|$))', re.UNICODE)
+    whitespacePattern = u'\u0000\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u2000\u2001\u2002\u2003'
+    whitespacePattern += u'\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u200B\u2028\u2029\u202F\u205F\u3000\uFEFF'
+    slugBlacklist = whitespacePattern + u'\u005B\u005C\u005D\u007B\u007D\u003A'
+    KEY_PATTERN     = re.compile(
+        r'^\s*(?P<key>[^' + slugBlacklist + r']+(?:\.[^' + slugBlacklist
+        + r']+)*)[ \t\r]*:[ \t\r]*(?P<value>.*(?:\n|\r|$))', re.UNICODE)
     ELEMENT_PATTERN = re.compile(r'^\s*\*[ \t\r]*(?P<value>.*(?:\n|\r|$))')
-    SCOPE_PATTERN   = re.compile(r'^\s*(?P<brace>\[|\{)[ \t\r]*(?P<flags>[\+\.]{0,2})(?P<scope_key>[\w-]*(?:\.[\w-]+)*)[ \t\r]*(?:\]|\}).*?(?:\n|\r|$)', re.UNICODE)
+    SCOPE_PATTERN   = re.compile(r'^\s*(?P<brace>\[|\{)[ \t\r]*(?P<flags>[\+\.]{0,2})(?P<scope_key>[^'
+            + slugBlacklist + r']*(?:\.[\w-]+)*)[ \t\r]*(?:\]|\}).*?(?:\n|\r|$)', re.UNICODE)
 
 
     def __init__(self):


### PR DESCRIPTION
This pull request closes #12 

In the official `sandbox.js` code, the regex patterns use a blacklist to match keys and scopes (anything but `{}[]:`). The current `\w-` skips valid ArchieML keys containing `(` or `/`, for instance. Here's a test file:
[test_unicode.txt](https://github.com/brainkim/archieml-python/files/1373575/test_unicode.txt)
